### PR TITLE
Add `oauth` command and remove `app` and `role` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ This section defines the OAuth2 configuration necessary to talk to OneLogin
 API servers.  You will need to get this from your administrator.
 
 ```yaml
-client_id: <OneLogin Client ID>
-client_secret: <OneLogin Client Secret>
 region: <OneLogin Region>
 username: <OneLogin Username>
 subdomain: <OneLogin Subdomain>
@@ -59,8 +57,6 @@ mfa: <device_id>
 
 Where:
 
- * `client_id`  - OneLogin OAuth2 client ID (required)
- * `client_secret`  - OneLogin OAuth2 client secret (required)
  * `region`  - One of `us` or `eu` depending on OneLogin server region to use (required)
  * `username` - Your OneLogin username/email address (required)
  * `subdomain` - Your organization's OneLoging subdomain (required)
@@ -124,6 +120,22 @@ calling `iam:ListAccountAliases` to determine the alias.
 After you have edited your `~/.onelogin.yaml` config file, you can verify it by
 running `onelogin-aws-role` and you should see a list of AWS Accounts and Roles that
 you have configured.
+
+### Configure your OneLogin ClientId and Client Secret
+
+All API calls to OneLogin [require a valid Oauth access token](
+https://developers.onelogin.com/api-docs/2/oauth20-tokens/generate-tokens-2).  In
+order to get one of these tokens, you must first authenticate to the OneLogin service
+using the ClientId and Client Secret provided to you by your administrator.  Both
+ClientId and Client Secrets are 64 character hex strings.
+
+##### Set ClientId and Client Secret
+
+`onelogin-aws-role oauth set`
+
+##### Show ClientId and Client Secret
+
+`onelogin-aws-role oauth show`
 
 ### Get STS Session Token for an IAM Role
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -39,16 +39,14 @@ import (
 
 // ConfigFile structure
 type ConfigFile struct {
-	ClientID     string                `yaml:"client_id"`
-	ClientSecret string                `yaml:"client_secret"`
-	Region       string                `yaml:"region"`                           // OneLogin Region
-	Username     string                `yaml:"username"`                         // or email address
-	Subdomain    string                `yaml:"subdomain"`                        // XXXX.onelogin.com
-	Mfa          int32                 `yaml:"mfa"`                              // MFA device_id to use by default
-	Duration     uint32                `yaml:"duration"`                         // Default duration (in seconds) for credentials
-	Accounts     *map[uint64]string    `yaml:"aws_accounts" header:"AccountID"`  // AWS AccountID is the key
-	Apps         *map[uint32]AppConfig `yaml:"apps" header:"AppID"`              // OneLogin AppID is the key
-	Fields       *[]string             `yaml:"fields,omitempty" header:"Fields"` // List of fields to report with `list` command
+	Region    string                `yaml:"region"`                           // OneLogin Region
+	Username  string                `yaml:"username"`                         // or email address
+	Subdomain string                `yaml:"subdomain"`                        // XXXX.onelogin.com
+	Mfa       int32                 `yaml:"mfa"`                              // MFA device_id to use by default
+	Duration  uint32                `yaml:"duration"`                         // Default duration (in seconds) for credentials
+	Accounts  *map[uint64]string    `yaml:"aws_accounts" header:"AccountID"`  // AWS AccountID is the key
+	Apps      *map[uint32]AppConfig `yaml:"apps" header:"AppID"`              // OneLogin AppID is the key
+	Fields    *[]string             `yaml:"fields,omitempty" header:"Fields"` // List of fields to report with `list` command
 }
 
 // App config

--- a/cmd/keyring.go
+++ b/cmd/keyring.go
@@ -105,3 +105,27 @@ func (kr *KeyringCache) GetSTSSession(profile string, session *aws.STSSession) e
 	}
 	return nil
 }
+
+func (kr *KeyringCache) GetOauthConfig(oauth *OauthConfig) error {
+	data, err := kr.keyring.Get("oauth:config")
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(data.Data, oauth)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (kr *KeyringCache) SaveOauthConfig(oauth OauthConfig) error {
+	jdata, err := json.Marshal(oauth)
+	if err != nil {
+		return err
+	}
+	err = kr.keyring.Set(keyring.Item{
+		Key:  "oauth:config",
+		Data: jdata,
+	})
+	return err
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,9 +19,13 @@ package main
  */
 
 import (
-	log "github.com/sirupsen/logrus"
+	"fmt"
 
+	"github.com/Songmu/prompter"
 	"github.com/alecthomas/kong"
+	"github.com/davecgh/go-spew/spew"
+	log "github.com/sirupsen/logrus"
+	"github.com/synfinatic/onelogin-aws-role/aws"
 	"github.com/synfinatic/onelogin-aws-role/onelogin"
 )
 
@@ -48,10 +52,11 @@ type CLI struct {
 	Duration int64  `kong:"optional,short='d',help='AWS Session duration in minutes (default: 1hr)',default=60"`
 
 	// Commands
-	Role RoleCmd `kong:"cmd,help='Fetch & cache AWS STS Token for a given Role/Profile'"`
-	App  AppCmd  `kong:"cmd,help='Fetch & cache all AWS STS Tokens for a given OneLogin AppID'"`
-	Exec ExecCmd `kong:"cmd,help='Execute command using specified AWS Role/Profile.'"`
-	List ListCmd `kong:"cmd,help='List all role / appid aliases (default command)',default='1'"`
+	//	Role RoleCmd `kong:"cmd,help='Fetch & cache AWS STS Token for a given Role/Profile'"`
+	//	App   AppCmd   `kong:"cmd,help='Fetch & cache all AWS STS Tokens for a given OneLogin AppID'"`
+	Exec  ExecCmd  `kong:"cmd,help='Execute command using specified AWS Role/Profile.'"`
+	List  ListCmd  `kong:"cmd,help='List all role / appid aliases (default command)',default='1'"`
+	Oauth OauthCmd `kong:"cmd,help='Manage OneLogin Oauth credentials'"`
 	// Revoke -- much later
 }
 
@@ -94,4 +99,111 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error running command: %s", err.Error())
 	}
+}
+
+func GetSession(ctx *RunContext, profile string) (aws.STSSession, error) {
+	session := aws.STSSession{}
+	kr, err := OpenKeyring(nil)
+	if err != nil {
+		log.WithError(err).Warn("Unable to retrieve STS Session from Keychain")
+	} else {
+		err = kr.GetSTSSession(profile, &session)
+		if err != nil {
+			log.WithError(err).Warn("Unable to read STS Session from Keychain")
+		}
+		if session.Expired() {
+			log.Warn("Cached STS SessionToken has expired")
+		}
+	}
+
+	if session.Expired() {
+		session, err = Login(ctx, profile)
+		if err != nil {
+			log.WithError(err).Fatal("Unable to get STSSession")
+		}
+		err = kr.SaveSTSSession(profile, session)
+		if err != nil {
+			log.WithError(err).Warn("Unable to cache STS Session in Keychain")
+		}
+	}
+	return session, nil
+}
+
+func Login(ctx *RunContext, profile string) (aws.STSSession, error) {
+	cli := *ctx.Cli
+	cfile, err := LoadConfigFile(GetPath(cli.ConfigFile))
+	if err != nil {
+		return aws.STSSession{}, fmt.Errorf("Unable to open %s: %s", cli.ConfigFile, err.Error())
+	}
+
+	kr, err := OpenKeyring(nil)
+	if err != nil {
+		return aws.STSSession{}, fmt.Errorf("Unable to open KeyChain for OneLogin Oauth: %s", err)
+	}
+	oauth := OauthConfig{}
+	err = kr.GetOauthConfig(&oauth)
+	if err != nil {
+		return aws.STSSession{}, fmt.Errorf("Please configure Oauth credentials")
+	}
+
+	o, err := onelogin.NewOneLogin(oauth.ClientId, oauth.Secret, ctx.Config.Region)
+	if err != nil {
+		log.WithError(err).Fatal("Unable to connect to OneLogin")
+	}
+	log.Debugf("config = %s", spew.Sdump(ctx.Config))
+	appid, err := ctx.Config.GetAppIdForRole(profile)
+	if err != nil {
+		return aws.STSSession{}, err
+	}
+
+	ols := &onelogin.OneLoginSAML{}
+	need_mfa := false
+	passwd_auth_pass := false
+	for !passwd_auth_pass {
+		passwd := prompter.Password("Enter your OneLogin password")
+
+		if passwd == "" {
+			return aws.STSSession{}, fmt.Errorf("OneLogin authentication aborted")
+		}
+		ols = onelogin.NewOneLoginSAML(o)
+		need_mfa, err = ols.GetAssertion(ctx.Config.Username, passwd, ctx.Config.Subdomain, appid, "")
+		if err == nil {
+			passwd_auth_pass = true
+		}
+	}
+
+	if need_mfa {
+		log.Info("MFA Required")
+		success, err := ols.SubmitMFA(ctx.Config.Mfa, appid)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if !success {
+			log.Fatalf("MFA auth failed.")
+		}
+	}
+	assertion, err := ols.OneLogin.Cache.GetAssertion(appid)
+	if err != nil {
+		log.Fatalf("Unable to get SAML Assertion: %s", err.Error())
+	} else {
+		log.Infof("Got SAML Assertion:\n%s", assertion)
+	}
+
+	role, err := cfile.GetRoleArn(profile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var region string
+	if cli.Region != "" {
+		region = cli.Region
+	} else {
+		region, err = cfile.GetRoleRegion(profile)
+		if err != nil {
+			log.WithError(err).Warn("Unable to set default AWS region, falling back to us-east-1")
+			region = "us-east-1"
+		}
+	}
+
+	return aws.GetSTSSession(assertion, role, region, cli.Duration*60)
 }

--- a/cmd/oauth.go
+++ b/cmd/oauth.go
@@ -1,0 +1,98 @@
+package main
+
+/*
+ * OneLogin AWS Role
+ * Copyright (c) 2020-2021 Aaron Turner  <aturner at synfin dot net>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/Songmu/prompter"
+	log "github.com/sirupsen/logrus"
+	"github.com/synfinatic/onelogin-aws-role/utils"
+)
+
+type OauthCmd struct {
+	Show OauthShowCmd `kong:"cmd,help='Show Oauth UserId/Secret',default='1'"`
+	Set  OauthSetCmd  `kong:"cmd,help='Set Oauth UserId/Secret'"`
+}
+
+type OauthSetCmd struct{}
+type OauthShowCmd struct{}
+
+type OauthConfig struct {
+	ClientId string `json:"clientid" header:"OneLogin ClientId"`
+	Secret   string `json:"secret" header:"OneLogin Secret"`
+}
+
+func (oc *OauthShowCmd) Run(ctx *RunContext) error {
+	kr, err := OpenKeyring(nil)
+	if err != nil {
+		return fmt.Errorf("Unable to get OauthConfig: %s", err)
+	}
+
+	oauth := &OauthConfig{}
+	err = kr.GetOauthConfig(oauth)
+	if err != nil {
+		return fmt.Errorf("Unable to get OauthConfig: %s", err)
+	}
+
+	ts := []utils.TableStruct{}
+	ts = append(ts, *oauth)
+	fields := []string{"ClientId", "Secret"}
+	utils.GenerateTable(ts, fields)
+
+	return nil
+}
+
+func (oc *OauthSetCmd) Run(ctx *RunContext) error {
+	kr, err := OpenKeyring(nil)
+	if err != nil {
+		return err
+	}
+
+	clientid := ""
+	for len(clientid) != 64 {
+		clientid = prompter.Prompt("OneLogin ClientId", "")
+
+		if len(clientid) != 64 {
+			log.Error("Invalid OneLogin ClientId: Must be 64 characters long")
+		}
+	}
+
+	secret := ""
+	for len(secret) != 64 {
+		secret = prompter.Password("OneLogin Secret")
+
+		if len(secret) != 64 {
+			log.Error("Invalid OneLogin Secret: Must be 64 characters long")
+		}
+	}
+
+	o := OauthConfig{
+		ClientId: clientid,
+		Secret:   secret,
+	}
+	return kr.SaveOauthConfig(o)
+}
+
+// Necessary for util.GenerateTable
+func (oc OauthConfig) GetHeader(fieldName string) (string, error) {
+	v := reflect.ValueOf(oc)
+	return utils.GetHeaderTag(v, fieldName)
+}

--- a/cmd/role.go
+++ b/cmd/role.go
@@ -18,6 +18,7 @@ package main
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/*
 import (
 	"fmt"
 
@@ -37,35 +38,6 @@ func (cc *RoleCmd) Run(ctx *RunContext) error {
 	_, err := GetSession(ctx, cli.Role.Profile)
 	return err
 }
-
-func GetSession(ctx *RunContext, profile string) (aws.STSSession, error) {
-	session := aws.STSSession{}
-	kr, err := OpenKeyring(nil)
-	if err != nil {
-		log.WithError(err).Warn("Unable to retrieve STS Session from Keychain")
-	} else {
-		err = kr.GetSTSSession(profile, &session)
-		if err != nil {
-			log.WithError(err).Warn("Unable to read STS Session from Keychain")
-		}
-		if session.Expired() {
-			log.Warn("Cached STS SessionToken has expired")
-		}
-	}
-
-	if session.Expired() {
-		session, err = Login(ctx, profile)
-		if err != nil {
-			log.WithError(err).Fatal("Unable to get STSSession")
-		}
-		err = kr.SaveSTSSession(profile, session)
-		if err != nil {
-			log.WithError(err).Warn("Unable to cache STS Session in Keychain")
-		}
-	}
-	return session, nil
-}
-
 func Login(ctx *RunContext, profile string) (aws.STSSession, error) {
 	cli := *ctx.Cli
 	cfile, err := LoadConfigFile(GetPath(cli.ConfigFile))
@@ -73,7 +45,17 @@ func Login(ctx *RunContext, profile string) (aws.STSSession, error) {
 		return aws.STSSession{}, fmt.Errorf("Unable to open %s: %s", cli.ConfigFile, err.Error())
 	}
 
-	o, err := onelogin.NewOneLogin(ctx.Config.ClientID, ctx.Config.ClientSecret, ctx.Config.Region)
+	kr, err := OpenKeyring(nil)
+	if err != nil {
+		return aws.STSSession{}, fmt.Errorf("Unable to open KeyChain for OneLogin Oauth: %s", err)
+	}
+	oauth := OauthConfig{}
+	err = kr.GetOauthConfig(&oauth)
+	if err != nil {
+		return aws.STSSession{}, fmt.Errorf("Please configure Oauth credentials")
+	}
+
+	o, err := onelogin.NewOneLogin(oauth.ClientId, oauth.Secret, ctx.Config.Region)
 	if err != nil {
 		log.WithError(err).Fatal("Unable to connect to OneLogin")
 	}
@@ -134,3 +116,4 @@ func Login(ctx *RunContext, profile string) (aws.STSSession, error) {
 
 	return aws.GetSTSSession(assertion, role, region, cli.Duration*60)
 }
+*/


### PR DESCRIPTION
- Move oauth bearer access token into the KeyChain
- Remove `app` command since it's not implimented
- Remove `role` command since there's really no need for it
    (I kept the role.go code around for now)

Refs #16