### PR TITLE
Various small code cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 BUILDINFOSDET ?=
 PROGRAM_ARGS ?=
 
-PROJECT_VERSION           := 0.1.3
+PROJECT_VERSION           := 0.1.4
 DOCKER_REPO               := synfinatic
 PROJECT_NAME              := onelogin-aws-role
 PROJECT_TAG               := $(shell git describe --tags 2>/dev/null $(git rev-list --tags --max-count=1))
@@ -20,13 +20,14 @@ PROJECT_COMMIT            := $(shell git rev-parse HEAD)
 ifeq ($(PROJECT_COMMIT),)
 PROJECT_COMMIT            := NO-CommitID
 endif
+PROJECT_DELTA             := $(shell DELTA_LINES=$$(git diff | wc -l); if [ $${DELTA_LINES} -ne 0 ]; then echo $${DELTA_LINES} ; else echo "''" ; fi)
 VERSION_PKG               := $(shell echo $(PROJECT_VERSION) | sed 's/^v//g')
 LICENSE                   := GPLv3
 URL                       := https://github.com/$(DOCKER_REPO)/$(PROJECT_NAME)
 DESCRIPTION               := OneLogin Go AWS Assume Role
 BUILDINFOS                := $(shell date +%FT%T%z)$(BUILDINFOSDET)
 HOSTNAME                  := $(shell hostname)
-LDFLAGS                   := -X "main.Version=$(PROJECT_VERSION)" -X "main.Buildinfos=$(BUILDINFOS)" -X "main.Tag=$(PROJECT_TAG)" -X "main.CommitID=$(PROJECT_COMMIT)"
+LDFLAGS                   := -X "main.Version=$(PROJECT_VERSION)" -X "main.Delta=$(PROJECT_DELTA)" -X "main.Buildinfos=$(BUILDINFOS)" -X "main.Tag=$(PROJECT_TAG)" -X "main.CommitID=$(PROJECT_COMMIT)"
 OUTPUT_NAME               := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)-$(GOOS)-$(GOARCH)  # default for current platform
 # supported platforms for `make release`
 WINDOWS_BIN               := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)-windows-amd64.exe

--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ Where:
  * `arn`   - AWS ARN to assume (required)
  * `profile`  - Friendly name of this role and section of AWS_PROFILE to write to `~/.aws/credentials` (required)
  * `region`  - Configure the default AWS region.  Default: `us-east-1` (optional)
- * `duration`  - How many seconds your AssumeRole credentials should last by default
-    (optional, default is 3600, minimum 900 and max 43200)
 
 Note that you can configure multiple roles for each account, multiple accounts for
 each applications and multiple applications.
@@ -109,9 +107,6 @@ human readable names to the account list.
 aws_accounts:
     <account id>: <account alias/name>
 ```
-
-Note if you do not have an alias set for a given AWS Account Id, it will try
-calling `iam:ListAccountAliases` to determine the alias.
 
 ## Usage
 
@@ -137,6 +132,7 @@ ClientId and Client Secrets are 64 character hex strings.
 
 `onelogin-aws-role oauth show`
 
+<!--
 ### Get STS Session Token for an IAM Role
 
 `onelogin-aws-role role <profile name>`
@@ -144,6 +140,7 @@ ClientId and Client Secrets are 64 character hex strings.
 This will ask you to authenticate to OneLogin and then retrieve the STS Session Token
 for the specified IAM role and cache that in your Keychain.  If you have an existing
 cached STS Session Token for this role, it will renew it.
+-->
 
 ### Execute command with an IAM Role
 
@@ -166,6 +163,7 @@ Note that all the necessary shell environment variables will be set:
         https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
         `~/.aws/config` and `~/.aws/credentials`.
 
+<!--
 ### Cache All STS Session Tokens for a OneLogin Application
 
 `onelogin-aws-role app <appid>`
@@ -174,6 +172,7 @@ This will authenticate you to OneLogin and retrieve and cache all of the STS
 Session Tokens for all the IAM roles associated with this OneLogin Application.  Further
 calls to `onelogin-aws-role exec <profile> ...` which are contained in that OneLogin 
 Application will not require re-authentication until the STS Session Tokens expire.
+-->
 
 ## Other Files
 
@@ -181,6 +180,13 @@ onelogin-aws-role will create the following file(s):
 
  * `~/.onelogin-aws-role.cache`
 	Contains SAML Assertions (good for ~3min) and the OneLogin bearer token (good for ~10hrs)
+
+## Environment Variables
+
+The following environment variables are honored to specify defaults:
+
+ * `ONELOGIN_AWS_DURATION` -- Default number of minutes to request the STS Session to be good for
+ * `AWS_DEFAULT_REGION` -- Default AWS Region to make API calls to
 
 ## License
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -39,14 +39,13 @@ import (
 
 // ConfigFile structure
 type ConfigFile struct {
-	Region    string                `yaml:"region"`                           // OneLogin Region
-	Username  string                `yaml:"username"`                         // or email address
-	Subdomain string                `yaml:"subdomain"`                        // XXXX.onelogin.com
-	Mfa       int32                 `yaml:"mfa"`                              // MFA device_id to use by default
-	Duration  uint32                `yaml:"duration"`                         // Default duration (in seconds) for credentials
-	Accounts  *map[uint64]string    `yaml:"aws_accounts" header:"AccountID"`  // AWS AccountID is the key
-	Apps      *map[uint32]AppConfig `yaml:"apps" header:"AppID"`              // OneLogin AppID is the key
-	Fields    *[]string             `yaml:"fields,omitempty" header:"Fields"` // List of fields to report with `list` command
+	Region    string                `yaml:"region"`                                    // OneLogin Region
+	Username  string                `yaml:"username"`                                  // or email address
+	Subdomain string                `yaml:"subdomain"`                                 // XXXX.onelogin.com
+	Mfa       int32                 `yaml:"mfa"`                                       // MFA device_id to use by default
+	Accounts  *map[uint64]string    `yaml:"aws_accounts,omitempty" header:"AccountID"` // AWS AccountID is the key
+	Apps      *map[uint32]AppConfig `yaml:"apps" header:"AppID"`                       // OneLogin AppID is the key
+	Fields    *[]string             `yaml:"fields,omitempty" header:"Fields"`          // List of fields to report with `list` command
 }
 
 // App config
@@ -116,8 +115,11 @@ func (c *ConfigFile) roleToFlatConfig(appid uint32, app AppConfig, role RoleConf
 	if err != nil {
 		log.WithError(err).Warnf("Unable to get AWS Account ID for role '%s'", role.Arn)
 	}
-	a := *c.Accounts
-	accountname, _ := a[accountid]
+	accountname := "<Unknown>"
+	if c.Accounts != nil {
+		a := *c.Accounts
+		accountname, _ = a[accountid]
+	}
 	fc := FlatConfig{
 		AccountId:   accountid,
 		AccountName: accountname,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ var Version = "unknown"
 var Buildinfos = "unknown"
 var Tag = "NO-TAG"
 var CommitID = "unknown"
+var Delta = ""
 
 type RunContext struct {
 	OneLogin *onelogin.OneLogin
@@ -49,7 +50,7 @@ type CLI struct {
 	ConfigFile string `kong:"optional,short='c',name='config',default='~/.onelogin-aws-role.yaml',help='Config file'"`
 	// AWS Params
 	Region   string `kong:"optional,short='r',help='AWS Region',env='AWS_DEFAULT_REGION'"`
-	Duration int64  `kong:"optional,short='d',help='AWS Session duration in minutes (default: 1hr)',default=60"`
+	Duration int64  `kong:"optional,short='d',help='AWS Session duration in minutes (default 60)',default=60,env=ONELOGIN_AWS_DURATION"`
 
 	// Commands
 	//	Role RoleCmd `kong:"cmd,help='Fetch & cache AWS STS Token for a given Role/Profile'"`
@@ -208,7 +209,12 @@ type VersionCmd struct {
 }
 
 func (cc *VersionCmd) Run(ctx *RunContext) error {
-	fmt.Printf("OneLogin AWS Role Version %s -- Copyright 2021 Aaron Turner\n", Version)
+	delta := ""
+	if len(Delta) > 0 {
+		delta = fmt.Sprintf(" [%s delta]", Delta)
+		Tag = "Unknown"
+	}
+	fmt.Printf("OneLogin AWS Role Version %s%s -- Copyright 2021 Aaron Turner\n", Version, delta)
 	fmt.Printf("%s (%s) built at %s\n", CommitID, Tag, Buildinfos)
 	return nil
 }


### PR DESCRIPTION
- `version` command now prints out the number of lines changed
- Remove `duration` from YAML config file
- Duration can now be set via `ONELOGIN_AWS_DURATION` env var
- Update README
- Refactor `list -f`
- Fix crash in `list` when account aliases are not defined
- Skip printing account alias column if aliases are not defined
- tag version 0.1.4