### PR TITLE
rename 'flush' to 'expire'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## v0.1.4 - 2021-05-11
 
 - Add support for `--prompt-mfa` to force promting for which MFA you want to use
-- Add support for `flush` command
+- Add support for `expire` command
 - Various code clean up & refactoring
 - Fix crash in `list` command when account aliases are not defined
 - Add support for `ONELOGIN_AWS_DURATION` environment variable

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ calls to `onelogin-aws-role exec <profile> ...` which are contained in that OneL
 Application will not require re-authentication until the STS Session Tokens expire.
 -->
 
-### Flush stored STS Session Token / Credentials
+### Expire stored STS Session Token / Credentials
 
-`onelogin-aws-role flush <profile name>`
+`onelogin-aws-role expire <profile name>`
 
-This will flush the stored credentials and force you to re-authenticate to use this role again.
+This will force expire (zero out) the stored credentials and force you to re-authenticate to use this role again.
 
 ## Other Files
 

--- a/cmd/expire.go
+++ b/cmd/expire.go
@@ -22,15 +22,15 @@ import (
 	"fmt"
 )
 
-type FlushCmd struct {
+type ExpireCmd struct {
 	Profile string `kong:"arg,required,name='profile',help='AWS Role alias name'"`
 }
 
-func (cc *FlushCmd) Run(ctx *RunContext) error {
+func (cc *ExpireCmd) Run(ctx *RunContext) error {
 	cli := *ctx.Cli
 	kr, err := OpenKeyring(nil)
 	if err != nil {
 		return fmt.Errorf("Unable to open KeyChain: %s", err)
 	}
-	return kr.RemoveSTSSession(cli.Flush.Profile)
+	return kr.RemoveSTSSession(cli.Expire.Profile)
 }

--- a/cmd/keyring.go
+++ b/cmd/keyring.go
@@ -150,6 +150,7 @@ func (kr *KeyringCache) RemoveSTSSession(profile string) error {
 	}
 
 	// Can't just call keyring.Remove() because it's broken, so we'll update the record instead
+	// return kr.keyring.Remove(key)
 	session := aws.STSSession{}
 	err = kr.GetSTSSession(profile, &session)
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,10 +57,10 @@ type CLI struct {
 	// Commands
 	//	Role RoleCmd `kong:"cmd,help='Fetch & cache AWS STS Token for a given Role/Profile'"`
 	//	App   AppCmd   `kong:"cmd,help='Fetch & cache all AWS STS Tokens for a given OneLogin AppID'"`
-	Exec  ExecCmd  `kong:"cmd,help='Execute command using specified AWS Role/Profile'"`
-	List  ListCmd  `kong:"cmd,help='List all role / appid aliases (default command)',default='1'"`
-	Oauth OauthCmd `kong:"cmd,help='Manage OneLogin Oauth credentials'"`
-	Flush FlushCmd `kong:"cmd,help='Flush AWS Role/Profile credentials from keychain'"`
+	Exec   ExecCmd   `kong:"cmd,help='Execute command using specified AWS Role/Profile'"`
+	List   ListCmd   `kong:"cmd,help='List all role / appid aliases (default command)',default='1'"`
+	Oauth  OauthCmd  `kong:"cmd,help='Manage OneLogin Oauth credentials'"`
+	Expire ExpireCmd `kong:"cmd,help='Force expire of AWS Role/Profile credentials from keychain'"`
 	// Revoke -- much later
 	Version VersionCmd `kong:"cmd,help='Print version and exit'"`
 }


### PR DESCRIPTION
More consistent terminology to be less confusing